### PR TITLE
test: stale PR bot auto demo (leave for 7 days)

### DIFF
--- a/test_stale_auto.md
+++ b/test_stale_auto.md
@@ -1,0 +1,1 @@
+# Auto Stale PR Demo\nThis PR is created to test the stale PR bot with automatic cron trigger.\nIt should be marked stale after 7 days of inactivity.\n


### PR DESCRIPTION
This PR tests the stale PR bot automatic trigger. It will have changes requested and be left untouched so the daily cron job can mark it stale after 7 days.